### PR TITLE
Stage 1 – Day 1: AWS account & IAM setup notes

### DIFF
--- a/docs/notes/stage-1-notes.md
+++ b/docs/notes/stage-1-notes.md
@@ -1,1 +1,21 @@
 
+# Stage 1 – AWS & Cloud Security: Notes
+
+## Day 1 – AWS account & IAM setup
+
+### What I did
+- Enabled MFA for the root user.
+- Verified the root user has **no active access keys**.
+- Created IAM admin user (`shimon-admin`) inside the `Admins` group.
+- Enabled MFA for the `shimon-admin` user.
+- Configured AWS CLI with the profile `shimon-admin`.
+- Tested CLI access with `aws sts get-caller-identity --profile shimon-admin`.
+
+### Key security decisions
+- Root user will never be used for day-to-day work.
+- IAM admin user is protected with MFA and is the only one used for console/CLI access.
+- No long-term credentials will be created unless required, and will be rotated periodically.
+
+### Notes / Follow-ups
+- Consider later creating “least-privilege” roles for Terraform and CI/CD.
+- Consider enforcing password policy and enabling AWS Organizations SCPs in the future.


### PR DESCRIPTION
Stage 1 – AWS & Cloud Security, Day 1.

- Configured root account MFA and verified no active root access keys.
- Created `shimon-admin` IAM user in `Admins` group with AdministratorAccess and MFA.
- Configured AWS CLI profile `shimon-admin`.
- Added notes in `docs/notes/stage-1-notes.md`.

Closes #1
